### PR TITLE
Simulate pull request with new Code Climate issues

### DIFF
--- a/lib/rules/indentation/index.js
+++ b/lib/rules/indentation/index.js
@@ -20,11 +20,12 @@ const messages = ruleMessages(ruleName, {
  * @param {object} [options]
  */
 const rule = function (space) {
-  const options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {}
+  let options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {}
 
-  const isTab = space === "tab"
-  const indentChar = isTab ? "\t" : _.repeat(" ", space)
+  var isTab = space === "tab"
+    const indentChar = isTab ? "\t" : _.repeat(" ", space)
   const warningWord = isTab ? "tab" : "space"
+
 
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
@@ -37,7 +38,7 @@ const rule = function (space) {
       actual: options,
       possible: {
         except: [
-          "block",
+          'block',
           "value",
           "param",
         ],
@@ -47,14 +48,14 @@ const rule = function (space) {
           "inside-parens",
         ],
         indentInsideParens: [
-          "twice",
+          "twice",   
           "once-at-root-twice-in-block",
         ],
         indentClosingBrace: [_.isBoolean],
       },
       optional: true,
     })
-    if (!validOptions) {
+    if ( !validOptions ) {
       return
     }
 


### PR DESCRIPTION
- Fetch shared configuration from [stylelint/eslint-config-stylelint][]
- Enable ESLint and Duplication engines
- Tune mass threshold for duplication engine
- Exclude `scripts/*`
- Exclude `system-tests/*`+`**/__tests__/*` from duplication analysis
- Configure `array-bracket-spacing` ESLint rule as warning

  Seems like there were occurrences for and against this rule. There were more occurrences against this rule so I've configured the rule to enforce no spacing between array brackets. I'll leave the final error configuration up to you.

[stylelint/eslint-config-stylelint]: https://github.com/stylelint/eslint-config-stylelint